### PR TITLE
feat: render travel spots dynamically using Country and Spot classes

### DIFF
--- a/01_travel_spot/js/main.js
+++ b/01_travel_spot/js/main.js
@@ -1,0 +1,29 @@
+import { Country } from "./Country.js";
+
+const countries = [
+    new Country("アメリカ", "スケールの大きさを体感できる自由の国", "#FF4C05", ["カリフォルニア・アドベンチャーパーク", "グリフィス天文台", "サルベーション・マウンテン", "サンタモニカ"]),
+    new Country("オーストラリア", "広大な自然と都市の魅力が共存する国", "#163DF0", ["ブルーマウンテン", "オペラハウス", "ブリスベンサイン", "コアラサンクチュアリ", "グレート・オーシャン・ロード", "ハートリーフ島", "ロットネスト島"]),
+    new Country("インド", "非日常なカオスを体験", "#FFA07A", ["インド門", "タージマハル"]),
+    new Country("インドネシア", "東南アジアらしい雑多な魅力の国", "purple", ["モナス", "インドネシア国立美術館", "ストリートフード"]),
+    new Country("マレーシア", "熱帯の香りと都会の活気が混ざる国", "lightgreen", ["バトゥ洞窟", "クアラルンプール・シティ・ギャラリー", "ペトロナス・ツインタワー"]), 
+    new Country("フィリピン", "ビーチと自然を満喫できる国", "lightblue", ["モアルボアル"]),
+    new Country("シンガポール", "東南アジアNo.1の経済大国", "orange", ["チャンギ国際空港", "ガーデンズ・バイ・ザ・ベイ", "ホーカー", "マーライオン"]),
+    new Country("タイ", "寺院とストリートの活気を体験できる国", "green", ["アユタヤ遺跡", "カオサン通り", "ワットアルン", "ワットパクナム"]), 
+    new Country("ベトナム", "急成長中の活気ある都市と自然を楽しめる国", "red", ["ドンコイ通り", "メコン川", "戦争博物館"])
+];
+
+let cardHtml = countries.map(country => country.getCardHtml()).join('');
+
+let container = `
+    <div class="container p-5">
+        <div class="row d-flex justify-content-center g-4 flex-wrap">
+            ${ cardHtml }
+        </div>
+    </div>
+`;  
+
+let spotsHtml = countries.map(country => country.getRecommendationSpots()).join('');
+
+const travelSpotsHtml = container + spotsHtml;
+
+document.getElementById("spots").innerHTML = travelSpotsHtml;


### PR DESCRIPTION
## 変更内容
- `countries` 配列を定義し、各国を `Country` クラスでインスタンス化
- `getCardHtml()` を使用して国カードのHTMLを生成し、トップページに表示
- `getSpotsHtml()` を使用しておすすめスポット一覧を生成
- `cardHtml` を含んだ `container` と `spotsHtml` を結合し、`#spots` 要素に挿入するDOM操作を追加

## 背景
- 従来はHTMLに静的に記述していたため、観光スポットや国を追加するたびにHTMLを直接編集する必要があり、メンテナンス性が低い状態でした
- 今回の変更により、データを追加するだけでHTMLを動的に生成でき、拡張性と保守性が向上しました