### PR TITLE
refactor: modify varible and method name to adjust Country class

### DIFF
--- a/01_travel_spot/js/main.js
+++ b/01_travel_spot/js/main.js
@@ -22,7 +22,7 @@ let container = `
     </div>
 `;  
 
-let spotsHtml = countries.map(country => country.getRecommendationSpots()).join('');
+let spotsHtml = countries.map(country => country.getSpotsHtml()).join('');
 
 const travelSpotsHtml = container + spotsHtml;
 


### PR DESCRIPTION
## 変更内容

- Country クラスで定義されているメソッド名に合わせて getRecommendationSpots() → getSpotsHtml() に修正
- #spots 要素に挿入するHTMLの変数名を travelSpotsHtml に変更し、役割をより明確に

## 背景

- メソッド名の不一致によりコードの可読性が低下していたため
- innerHTML に渡す文字列を示す変数名として、travelSpotsHtml の方が意味が明確で理解しやすいため変更