### PR TITLE
chore: remove static spot HTML to prepare for dynamic generation

### DIFF
--- a/01_travel_spot/index.html
+++ b/01_travel_spot/index.html
@@ -15,71 +15,11 @@
         <h1>実際に行ってよかった！</h1>
         <h1>おすすめ海外観光スポット</h1>
     </div>
+    
     <div id="spots">
-        <div class="container p-5">
-            <div class="row d-flex justify-content-center g-4 flex-wrap">
-                <a href="#america" class="col-12 col-md-6 col-lg-4 text-decoration-none text-reset">
-                    <div class="card h-100 text-center text-white" style="background: #FF4C05">
-                        <img class="card-img-top img-aspect" src="./images/america/america.jpg" alt="america-image">
-                        <div class="card-body">
-                            <h3 class="card-title">アメリカ</h3>
-                            <p class="card-text">何もかもスケールが大きい自由の国</p>
-                        </div>
-                    </div>
-                </a>
-            </div>
-        </div>
-
-        <div id="america" style="background: #FF4C05;">
-            <div class="container p-4">
-                <div class="text-white">
-                    <h2>アメリカ</h2>
-                    <p>何もかもスケールが大きい自由の国</p>
-                </div>
-                <div class="row justify-content-between flex-wrap">
-                    <div class="col-12 col-md-5 d-flex bg-white px-0 g-4">
-                        <div class="col-8 p-3">
-                            <h4>カリフォルニア・アドベンチャーパーク</h4>
-                            <p>カリフォルニアの多様な文化や自然をテーマにした、アナハイムにあるディズニーパーク</p>
-                        </div>
-                        <div class="col-4 d-flex justify-content-center align-items-center">
-                            <img src="./images/america/adventure-park.jpg" alt="adventure-park" class="col-12 p-1 img-fluid img-aspect">
-                        </div>
-                    </div>
-
-                    <div class="col-12 col-md-5 d-flex bg-white px-0 g-4">
-                        <div class="col-8 p-3">
-                            <h4>グリフィス天文台</h4>
-                            <p>ロサンゼルスの丘の上にあり、ハリウッドサインとLAの街を一望できる有名な天文台</p>
-                        </div>
-                        <div class="col-4 d-flex justify-content-center align-items-center">
-                            <img src="./images/america/griffith-observatory.jpg" alt="griffith-observatoryk" class="col-12 p-1 img-fluid img-aspect">
-                        </div>
-                    </div>
-
-                    <div class="col-12 col-md-5 d-flex bg-white px-0 g-4">
-                        <div class="col-8 p-3">
-                            <h4>サルベーション・マウンテン</h4>
-                            <p>カリフォルニア州の砂漠に、愛と信仰をテーマに色彩豊かに描かれた巨大なアート作品</p>
-                        </div>
-                        <div class="col-4 d-flex justify-content-center align-items-center">
-                            <img src="./images/america/salvation-mountain.jpg" alt="salvation-mountain" class="col-12 p-1 img-fluid img-aspect">
-                        </div>
-                    </div>
-
-                    <div class="col-12 col-md-5 d-flex bg-white px-0 g-4">
-                        <div class="col-8 p-3">
-                            <h4>サンタモニカ</h4>
-                            <p>ロサンゼルス近郊にある、活気あふれる桟橋とビーチが人気</p>
-                        </div>
-                        <div class="col-4 d-flex justify-content-center align-items-center">
-                            <img src="./images/america/santa-monica.jpg" alt="santa-monica" class="col-12 p-1 img-fluid img-aspect">
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
     </div>
+
+    <script type="module" src="./js/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## 変更内容

index.html 内の <div id="spots"> 配下に記載されていた静的な観光スポットHTMLを削除

## 背景

- 観光スポット一覧を静的HTMLで管理していたため、スポット追加や変更時にHTMLを直接編集する必要があり、メンテナンス性が低かった課題があった
- 今後は JavaScriptで動的に生成する仕組みに移行するため、静的な記述を削除

## 目的

DOM操作による動的生成を容易にする準備のため