### PR TITLE
fix: call getSpots() instead of referencing function

### DIFF
--- a/01_travel_spot/js/Country.js
+++ b/01_travel_spot/js/Country.js
@@ -38,11 +38,11 @@ export class Country {
                         <p>${this.description}</p>
                     </div>
                     <div class="row justify-content-between flex-wrap">
-                        ${this.getSpots.map(spot => `
+                        ${this.getSpots().map(spot => `
                             <div class="col-12 col-md-5 d-flex bg-white px-0 g-4">
                                 <div class="col-8 p-3">
                                     <h4>${spot.name}</h4>
-                                    <p>${spot.description}</p>
+                                    <p>${spot.description}</p>  
                                 </div>
                                 <div class="col-4 d-flex justify-content-center align-items-center">
                                     <img src="${spot.image}" alt="${spot.name}" class="col-12 p-1 img-fluid img-aspect">


### PR DESCRIPTION
## 変更内容

- getSpotsHtml() メソッド内で `this.getSpots.map` を呼び出していた箇所を、正しく `this.getSpots().map` に修正
- 関数参照ではなく、メソッドを実行するように変更することで map が正しく動作するように修正

## 背景

- getSpots を関数参照のまま呼び出してしまい、`this.getSpots.map is not a function` エラーが発生していた
- バグの原因は単純に () の付け忘れによるメソッド未実行

## 修正理由

メソッド呼び出しを正しく行ない、配列に対して map() が適用できるようにするため